### PR TITLE
Add dependency installer script

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,1 @@
+pip install -r requirements.txt || exit 1


### PR DESCRIPTION
Currently, the doc-builder installs the packages required for each project by going through if-else statements as there are slight changes in the commands used for each project. Adding install_dependencies.sh script will allow the doc builder to generalise this process by having to just look for this script in the project directory.

The PR is related to the below task:
https://trello.com/c/VG4SYszL